### PR TITLE
Codex review コメントへの reaction と返信ルールを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,11 @@ Codex review returns a positive result. A positive result means either a visible
 not find major issues.
 
 If Codex review returns actionable comments, requested changes, or major issues,
-address them before considering the PR ready. After each fix:
+first decide whether each comment is valid. For each valid comment, the
+implementer adds a `+1` reaction to that review comment and replies with the fix
+or planned fix. For each invalid or inapplicable comment, do not add `+1`; reply
+with the reason it is not being applied or with the alternate approach. Then
+address valid comments before considering the PR ready. After each fix:
 
 1. update the implementation in the issue worktree,
 2. rerun the appropriate local validation,
@@ -103,7 +107,8 @@ address them before considering the PR ready. After each fix:
 
 Do not stop at PR creation when Codex review has not completed yet. Completion
 reports must state whether GitHub Codex review reached `+1` / no-major-issues,
-or explain why that check could not be completed.
+whether review comments received `+1` / replies as appropriate, or explain why
+that check could not be completed.
 
 ## Pull Request Language
 

--- a/docs/technical/parallel-issue-workflow.md
+++ b/docs/technical/parallel-issue-workflow.md
@@ -33,7 +33,9 @@ This section is the current source of truth for issue-to-PR operation in this re
    - Continue the PR work until Codex gives a positive result: a `+1` / thumbs-up reaction, or a Codex review/comment that says it did not find major issues.
    - Do not treat PR creation alone as completion while Codex review is still pending.
 9. Address PR review comments
-   - For each actionable comment, react and reply after fixing or explaining.
+   - Decide whether each Codex review comment is valid before editing.
+   - For valid comments, the implementer adds a `+1` reaction to that review comment and replies with the fix or planned fix.
+   - For invalid or inapplicable comments, do not add `+1`; reply with the reason or alternate approach.
    - Even when addressing Codex review comments, also run the local multi-agent review for the new diff before committing/pushing.
    - After fixes are pushed, request GitHub Codex review again and repeat until the positive result is reached.
 
@@ -48,6 +50,7 @@ Completion criteria for a worker thread:
 - branch is pushed
 - PR is created or updated with validation and review evidence
 - PR title and body are written in Japanese
+- Codex review comments have been reacted to and replied to according to validity
 - GitHub Codex review has reached `+1` / no-major-issues, or the blocker to completing that check is documented
 
 # Parallel Issue Workflow


### PR DESCRIPTION
## 概要

- Codex review コメントへの reaction / reply ルールを明文化しました。
- 妥当な review コメントには、実装者がその review comment に `+1` reaction を付け、修正内容または対応予定を返信することを追加しました。
- 妥当でない、または適用しない review コメントには `+1` を付けず、理由または代替方針を返信することを追加しました。
- 既存の Codex review `+1` / no-major-issues gate と矛盾しないよう、コメント対応後に local review gate と再 Codex review を回す流れへ接続しました。

## 検証

- `git diff --check` を確認しました。
- 秘密情報、Notion database ID、個人ローカルパス、private data の混入がないことを簡易スキャンしました。
- intent review: pass。
- fresh pre PR review: pass。

## 外部状態変更

- Issue #120 のための作業ブランチを作成し、この PR を作成しました。

Closes #120