### PR TITLE
Notion の Error ビューと論文DB要件を明文化する

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,61 @@ For Notion access:
 
 This repository does not store the token or database ID in tracked files.
 
-## 2. Prepare Private Data Storage
+## 2. Configure the Notion Paper Database
+
+Create or update the Notion `Paper Inbox` database with these required properties:
+
+| Property | Type |
+| --- | --- |
+| Title | Title |
+| Status | Status or Select |
+| PDF URL | URL |
+| Local Folder | Rich text |
+| Process Tags | Multi-select |
+| Error Message | Rich text |
+| Last Processed | Date |
+
+If you import GitHub Issues or sync GitHub Projects, also add:
+
+| Property | Type |
+| --- | --- |
+| GitHub Issue Number | Number |
+| GitHub Issue URL | URL |
+| Original Issue State | Select |
+| Paper Key | Rich text |
+| English Title | Rich text |
+| Authors | Rich text |
+| Year | Number |
+| Venue | Rich text |
+| DOI | Rich text |
+| arXiv ID | Rich text |
+| Source | Rich text |
+| Source URL | URL |
+| Short Summary JA | Rich text |
+| Reason | Rich text |
+| Relevance Note | Rich text |
+| Priority | Select |
+| Tags | Multi-select |
+| OA Status | Select |
+
+Set `Status` options for normal operation:
+
+- `Want to read`: ready for the CLI to prepare local files.
+- `Preparing`: the CLI or Codex is working on the card.
+- `Ready to read`: local reading files are ready, or the card is ready with a manual-check tag.
+- `Error`: automatic processing failed and needs review.
+
+You can keep existing cards. Add missing properties to the database, copy values from old lowercase properties such as `status` or `local folder` into the exact property names above, and avoid recreating cards only for schema cleanup.
+
+Create an `Error` view in Notion:
+
+- Filter: `Status` is `Error`.
+- Sort: `Last Processed` descending.
+- Show at least `Title`, `Status`, `Process Tags`, `Error Message`, `PDF URL`, `Local Folder`, and `Last Processed`.
+
+Do not paste Notion database IDs, integration tokens, local absolute paths, PDFs, extracted text, translations, or private notes into tracked files.
+
+## 3. Prepare Private Data Storage
 
 Create a private data directory outside this repository and set `PAPER_READING_DATA_ROOT` to that path.
 
@@ -37,7 +91,7 @@ The CLI will create folders like:
       notes.md
 ```
 
-## 3. Add Test Papers in Notion
+## 4. Add Test Papers in Notion
 
 Add a few cards to the Notion `Paper Inbox` database.
 
@@ -48,7 +102,7 @@ Status = Want to read
 PDF URL = <direct PDF URL if available>
 ```
 
-## 4. Run the CLI
+## 5. Run the CLI
 
 Preview what would happen:
 

--- a/docs/paper-reading-system-spec.md
+++ b/docs/paper-reading-system-spec.md
@@ -54,34 +54,50 @@ Notion では、論文1本を1つのカードとして扱う。
 
 論文カードには、読むかどうかを判断するための軽量な情報だけを置く。
 
-- title
-- authors
-- year
-- venue
-- source
-- DOI
-- arXiv ID
-- PDF URL
-- 3行概要
-- なぜ候補に入ったか
-- 自分の関心に近そうな点
-- priority
-- tags
-- status
-- GitHub Issue Number
-- GitHub Issue URL
-- Original Issue State
-- OA Status
-- local folder
-- process tags
-- error message
-- last processed
+### 必須プロパティ
+
+Notion database には、以下のプロパティを用意する。プロパティ名はスクリプトが参照するため、大文字小文字と空白を含めてこの表に合わせる。
+
+| Property | Notion type | 用途 |
+| --- | --- | --- |
+| Title | Title | 論文カードの表示名。 |
+| Status | Status または Select | 論文の運用状態。新規作成時は Notion の Status 型を推奨する。既存 database が Select 型の場合も互換として扱う。 |
+| PDF URL | URL | PDF を直接取得できる URL。空でもよい。 |
+| Local Folder | Rich text | private data storage 内のローカル作業フォルダ。 |
+| Process Tags | Multi-select | `pdf_missing`、`pdf_download_failed`、`needs_manual_check` などの処理タグ。 |
+| Error Message | Rich text | 最後に失敗した処理の理由。正常終了時は空にする。 |
+| Last Processed | Date | 最後に CLI または Codex が処理した日時。 |
+
+GitHub Issue からの import や GitHub Projects sync を使う場合は、以下も必須とする。
+
+| Property | Notion type | 用途 |
+| --- | --- | --- |
+| GitHub Issue Number | Number | 取り込み元 Issue 番号。 |
+| GitHub Issue URL | URL | 取り込み元 Issue URL。重複検出にも使う。 |
+| Original Issue State | Select | 取り込み時点の GitHub Issue state。 |
+| Paper Key | Rich text | ローカルフォルダ名を安定させるためのキー。 |
+| English Title | Rich text | Issue 本文などから抽出した英語タイトル。 |
+| Authors | Rich text | 著者。 |
+| Year | Number | 発行年。 |
+| Venue | Rich text | 会議、ジャーナル、プレプリントサーバーなど。 |
+| DOI | Rich text | DOI。 |
+| arXiv ID | Rich text | arXiv identifier。 |
+| Source | Rich text | 候補の入口や取り込み元。 |
+| Source URL | URL | 論文ページ、OA ページ、Issue 本文中の参照先など。 |
+| Short Summary JA | Rich text | 短い日本語概要。 |
+| Reason | Rich text | なぜ候補に入ったか。 |
+| Relevance Note | Rich text | 自分の関心に近そうな点。 |
+| Priority | Select | 読む優先度。 |
+| Tags | Multi-select | トピックや GitHub label 由来のタグ。 |
+| OA Status | Select | OA 判定。`gold`、`green`、`bronze`、`hybrid`、`closed`、`unknown` を使う。 |
+
+既存カードに互換性を持たせるため、データ移行ではカードを作り直さず、足りないプロパティを database に追加してから既存値を埋める。`Status` が Select 型の既存 database はそのまま運用できるが、新規 database では Status 型を使う。旧表記の `status`、`local folder`、`process tags`、`error message`、`last processed` などがある場合は、値をそれぞれ `Status`、`Local Folder`、`Process Tags`、`Error Message`、`Last Processed` へ移す。移行が終わるまで旧プロパティを残してもよいが、スクリプトから参照する正本は上記の英語名とする。
 
 PDF、全文抽出テキスト、全文対訳、詳細な個人メモは Notion に置かない。これらは private data storage に保存する。
 
 ## 論文カードの状態
 
-Notion の論文カードには `status` を持たせる。
+Notion の論文カードには `Status` を持たせる。
 
 | Status | 意味 |
 | --- | --- |
@@ -97,7 +113,18 @@ Notion の論文カードには `status` を持たせる。
 
 `Want to read` は、ユーザーが「この論文は読む価値がありそうなので、PDF取得や対訳生成まで進めてよい」と判断した印である。
 
-Codex は `Want to read` の論文を見つけると、処理開始時に `Preparing` に変更する。成功したら `Ready to read` に変更する。失敗したら `Error` に変更し、失敗理由を `process tags` と `error message` に残す。
+Codex は `Want to read` の論文を見つけると、処理開始時に `Preparing` に変更する。成功したら `Ready to read` に変更する。失敗したら `Error` に変更し、失敗理由を `Process Tags` と `Error Message` に残す。
+
+`Want to read`、`Preparing`、`Ready to read`、`Error` は、ローカル準備作業の中核状態として次のように運用する。
+
+| Status | 運用 |
+| --- | --- |
+| Want to read | ユーザーが準備を許可した状態。CLI の `prepare` はこの状態だけを処理対象にする。PDF URL が空でもカードは対象になり、ローカルフォルダ、metadata、notes を作る。 |
+| Preparing | CLI または Codex が処理中であることを示す一時状態。開始時に `Local Folder` と `Last Processed` を更新する。 |
+| Ready to read | 読むための最低限の準備が終わった状態。PDF がない場合でも、手動確認が必要なタグを残したうえで到達できる。 |
+| Error | 自動処理が失敗した状態。`Process Tags`、`Error Message`、`Last Processed` を必ず更新し、Error ビューで確認できるようにする。 |
+
+GitHub Projects sync が `Inbox`、`Later`、`Want to read` などへ戻す情報を持っていても、`Preparing`、`Ready to read`、`Reading`、`Error` のようなローカル作業状態を不用意に上書きしない。既存カードの作業状態は、ユーザーまたは明示的な再同期操作で変更する。
 
 ## Public repository と private data の境界
 
@@ -251,6 +278,14 @@ Last Processed = 2026-05-01 11:30
 ```
 
 Notion には `Error` の論文だけを見るビューを作る。
+
+Error ビューの要件:
+
+- view 名は `Error` とする。
+- filter は `Status` が `Error` と等しいカードだけにする。
+- 表示プロパティは少なくとも `Title`、`Status`、`Process Tags`、`Error Message`、`PDF URL`、`Local Folder`、`Last Processed` を含める。
+- `Last Processed` の降順で並べ、直近の失敗を先頭に出す。
+- このビューは失敗調査と再実行判断の入口であり、PDF、全文抽出テキスト、全文対訳、詳細メモ、Notion database ID、API token は表示にも本文にも置かない。
 
 詳細確認や再実行は Codex が CLI を使って行う。
 


### PR DESCRIPTION
## 概要

- Notion 論文DBの必須プロパティと型を getting-started と仕様書に明記しました。
- Status = Error ビューの filter / sort / 表示プロパティ要件を追加しました。
- Want to read / Preparing / Ready to read / Error の運用と、既存カードの互換・移行方針を整理しました。

## 対応 Issue

Closes #116

## 検証

- git diff --check（CRLF 変換警告のみ）
- intent review: pass
- fresh pre PR review: pass
- Notion database ID / token / private data / ローカル絶対パスが差分に含まれないことを確認

## Codex review

PR 作成後に @codex review を依頼します。