### PR TITLE
実装済み CLI と planned 項目の一覧を整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,37 @@ The public repository should still make sense without access to any private over
 
 See [docs/paper-reading-system-spec.md](docs/paper-reading-system-spec.md).
 
+## CLI Command Status
+
+Run implemented commands with:
+
+```powershell
+python scripts\paper_worker.py <command>
+```
+
+Implemented commands:
+
+| Command | Status | Notes |
+| --- | --- | --- |
+| `status` | Implemented | Shows Notion paper status counts. |
+| `prepare` | Implemented | Prepares `Want to read` papers by creating the private local folder, `metadata.json`, `notes.md`, and downloading `paper.pdf` when `PDF URL` is present. |
+| `import-github-issues` | Implemented | Imports GitHub Issues into Notion paper cards. |
+| `sync-github-project` | Implemented | Syncs GitHub Projects status and priority into imported Notion cards. |
+
+Planned commands and workflow work:
+
+| Planned item | Tracking issue | Notes |
+| --- | --- | --- |
+| `collect` | [#110](https://github.com/tomiokario/my-paper-reading-list/issues/110) | Add an entry point for candidate papers into the Notion Inbox. |
+| PDF text extraction and `summary.ja.md` | [#111](https://github.com/tomiokario/my-paper-reading-list/issues/111) | Generate private extracted text and summary files after PDF download. |
+| `translate` | [#112](https://github.com/tomiokario/my-paper-reading-list/issues/112) | Generate full parallel translations from private extracted text. |
+| `retry --failed` | [#113](https://github.com/tomiokario/my-paper-reading-list/issues/113) | Re-run failed paper processing based on Notion status and process tags. |
+| Background `prepare --keep-going` operation | [#114](https://github.com/tomiokario/my-paper-reading-list/issues/114) | Decide and document scheduled execution without storing local secrets or paths. |
+| `show paper-id` | [#115](https://github.com/tomiokario/my-paper-reading-list/issues/115) | Inspect a paper card and private local file presence without printing private file bodies. |
+| Notion Error view and schema docs | [#116](https://github.com/tomiokario/my-paper-reading-list/issues/116) | Document required database properties, views, and compatibility notes. |
+
+Do not treat planned items as available CLI commands until their tracking issues are implemented. PDFs, extracted text, translations, personal notes, logs, Notion IDs, tokens, and machine-specific paths must stay outside tracked files.
+
 ## Getting Started
 
 See [docs/getting-started.md](docs/getting-started.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,8 @@ PDF URL = <direct PDF URL if available>
 
 ## 4. Run the CLI
 
+This section lists implemented commands only. Planned commands such as `collect`, `translate`, `retry --failed`, and `show paper-id` are tracked in the README and should not be used until their issues are implemented.
+
 Preview what would happen:
 
 ```powershell
@@ -87,5 +89,6 @@ python scripts\paper_worker.py sync-github-project --owner owner --project-numbe
 
 - The CLI currently creates the local folder, `metadata.json`, `notes.md`, and downloads `paper.pdf` when `PDF URL` is present.
 - GitHub Projects sync uses the GitHub CLI, so `gh` must be installed and authenticated with `project`.
-- Full text extraction and translation are planned next.
+- Full text extraction, summary generation, translation, retry, diagnostic display, and background operation are planned in the linked issues in the README.
 - Notion IDs and tokens must stay in `.env` or another local-only configuration file.
+- PDF files, extracted text, translations, personal notes, logs, and machine-specific paths must stay in private data storage or local-only files, not in tracked repository files.

--- a/docs/paper-reading-system-spec.md
+++ b/docs/paper-reading-system-spec.md
@@ -235,6 +235,38 @@ paper-worker status
 paper-worker show paper-id
 ```
 
+## CLI implementation status
+
+This specification includes target commands that are not all implemented yet.
+The current public implementation status is summarized in
+[../README.md](../README.md#cli-command-status).
+
+Implemented commands:
+
+| Command | Current behavior |
+| --- | --- |
+| `status` | Shows Notion paper status counts. |
+| `prepare` | Prepares `Want to read` papers by creating private local files and downloading `paper.pdf` when `PDF URL` is present. |
+| `import-github-issues` | Imports GitHub Issues into Notion paper cards. |
+| `sync-github-project` | Syncs GitHub Projects status and priority into imported Notion cards. |
+
+Planned commands and dependent workflow work:
+
+| Planned item | Tracking issue |
+| --- | --- |
+| `collect` | [#110](https://github.com/tomiokario/my-paper-reading-list/issues/110) |
+| PDF text extraction and `summary.ja.md` | [#111](https://github.com/tomiokario/my-paper-reading-list/issues/111) |
+| `translate` | [#112](https://github.com/tomiokario/my-paper-reading-list/issues/112) |
+| `retry --failed` | [#113](https://github.com/tomiokario/my-paper-reading-list/issues/113) |
+| background `prepare --keep-going` operation | [#114](https://github.com/tomiokario/my-paper-reading-list/issues/114) |
+| `show paper-id` | [#115](https://github.com/tomiokario/my-paper-reading-list/issues/115) |
+| Notion Error view and schema docs | [#116](https://github.com/tomiokario/my-paper-reading-list/issues/116) |
+
+Planned items must not be documented as available CLI behavior until their tracking
+issues are implemented. Private data boundaries still apply: PDFs, extracted text,
+translations, personal notes, logs, Notion database IDs, API tokens, sync state, and
+machine-specific paths stay outside tracked repository files.
+
 ユーザーが困った場合は、Codex に CLI の出力やログを確認させて修正を依頼する。
 
 ## エラー処理


### PR DESCRIPTION
## 概要

- README に現在実装済みの CLI コマンド一覧を追加しました。
- planned 項目を Issue #110-#116 へのリンク付きで整理しました。
- getting-started と仕様書にも、未実装コマンドを利用可能な CLI として扱わない旨を追記しました。

## 対応 Issue

Closes #117

## 検証

- git diff --cached --check
- intent review: pass
- fresh pre PR review: pass
- private data / token / Notion ID / 実ローカルパスが差分に含まれないことを確認

## 残リスク

- この PowerShell 環境では python / py が未設定のため CLI help の実行確認は未実施です。docs-only 差分で、parser の静的確認では実装済みコマンド一覧と一致しています。

## Codex review

PR 作成後に @codex review を依頼します。