### PR TITLE
候補論文を Notion Inbox に登録する collect コマンドを追加する

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,44 @@ PDF URL = <direct PDF URL if available>
 
 ## 4. Run the CLI
 
+Collect candidate papers into the Notion Inbox from a local JSON file:
+
+```powershell
+python scripts\paper_worker.py collect --input candidates.json --dry-run
+python scripts\paper_worker.py collect --input candidates.json
+```
+
+The initial `collect` input is either one JSON object or an array of objects. `title` is required.
+Optional fields are `source_url` or `url`, `pdf_url`, `doi`, `arxiv_id`, `authors`, `year`,
+`venue`, `summary_ja`, `reason`, `relevance_note`, `priority`, `tags`, and `source`.
+
+Example:
+
+```json
+[
+  {
+    "title": "Example Paper",
+    "source_url": "https://doi.org/10.1234/example",
+    "pdf_url": "https://example.com/paper.pdf",
+    "authors": ["A. Researcher", "B. Author"],
+    "year": 2026,
+    "venue": "ExampleConf",
+    "summary_ja": "Short Japanese summary",
+    "reason": "Why this should be considered",
+    "relevance_note": "How this connects to the reading list",
+    "priority": "Medium",
+    "tags": ["survey"],
+    "source": "manual"
+  }
+]
+```
+
+`collect --dry-run` queries Notion, prints cards that would be created, and prints duplicate skips
+without creating pages. Duplicate checks use DOI, arXiv ID, Source URL, Paper Key, and Title against
+existing Notion pages and earlier items in the same input file. New cards are created with
+`Status = Inbox`. Notion tokens, database IDs, and private paper data must stay in `.env` or other
+local-only files, not in `candidates.json` or tracked docs.
+
 Preview what would happen:
 
 ```powershell
@@ -86,6 +124,7 @@ python scripts\paper_worker.py sync-github-project --owner owner --project-numbe
 ## Notes
 
 - The CLI currently creates the local folder, `metadata.json`, `notes.md`, and downloads `paper.pdf` when `PDF URL` is present.
+- `collect` creates Notion Inbox cards only; it does not download PDFs or write private data.
 - GitHub Projects sync uses the GitHub CLI, so `gh` must be installed and authenticated with `project`.
 - Full text extraction and translation are planned next.
 - Notion IDs and tokens must stay in `.env` or another local-only configuration file.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,6 +60,8 @@ python scripts\paper_worker.py collect --input candidates.json
 The initial `collect` input is either one JSON object or an array of objects. `title` is required.
 Optional fields are `source_url` or `url`, `pdf_url`, `doi`, `arxiv_id`, `authors`, `year`,
 `venue`, `summary_ja`, `reason`, `relevance_note`, `priority`, `tags`, and `source`.
+`tags` can be a JSON array or a comma-separated string. `priority` and each tag must not contain
+commas after normalization because Notion select option names do not allow commas.
 
 Example:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ PDF URL = <direct PDF URL if available>
 
 ## 5. Run the CLI
 
-This section lists implemented commands only. Planned commands such as `collect`, `translate`, `retry --failed`, and `show paper-id` are tracked in the README and should not be used until their issues are implemented.
+This section lists implemented commands only. Planned commands such as `translate`, `retry --failed`, and `show paper-id` are tracked in the README and should not be used until their issues are implemented.
 
 Collect candidate papers into the Notion Inbox from a local JSON file:
 

--- a/docs/paper-reading-system-spec.md
+++ b/docs/paper-reading-system-spec.md
@@ -366,6 +366,9 @@ tags
 source
 ```
 
+`tags` can be a JSON array or a comma-separated string. `priority` and each normalized tag must not
+contain commas because Notion select and multi-select option names do not allow commas.
+
 Example:
 
 ```json

--- a/docs/paper-reading-system-spec.md
+++ b/docs/paper-reading-system-spec.md
@@ -274,6 +274,7 @@ Implemented commands:
 | --- | --- |
 | `status` | Shows Notion paper status counts. |
 | `prepare` | Prepares `Want to read` papers by creating private local files and downloading `paper.pdf` when `PDF URL` is present. |
+| `collect` | Creates Notion Inbox cards from a local candidate JSON file, with dry-run support and duplicate checks by DOI, arXiv ID, Source URL, Paper Key, and Title. |
 | `import-github-issues` | Imports GitHub Issues into Notion paper cards. |
 | `sync-github-project` | Syncs GitHub Projects status and priority into imported Notion cards. |
 
@@ -281,7 +282,6 @@ Planned commands and dependent workflow work:
 
 | Planned item | Tracking issue |
 | --- | --- |
-| `collect` | [#110](https://github.com/tomiokario/my-paper-reading-list/issues/110) |
 | PDF text extraction and `summary.ja.md` | [#111](https://github.com/tomiokario/my-paper-reading-list/issues/111) |
 | `translate` | [#112](https://github.com/tomiokario/my-paper-reading-list/issues/112) |
 | `retry --failed` | [#113](https://github.com/tomiokario/my-paper-reading-list/issues/113) |

--- a/docs/paper-reading-system-spec.md
+++ b/docs/paper-reading-system-spec.md
@@ -333,3 +333,66 @@ Codex は以下に使う。
 5. Codex によるローカル作業は手動依頼にするか、定期的に確認する運用にするか。
 6. PDF 取得は OA のみとするか、ユーザーが手動で入れた PDF も対象にするか。
 7. 関連論文整理はいつから必要か。
+
+## `paper-worker collect` initial contract
+
+`paper-worker collect` is the first CLI entry point for registering candidate papers in the Notion
+Paper Inbox. It accepts a local JSON file and does not require or store PDF files, extracted text,
+translation output, Notion database IDs, tokens, or private data in tracked files.
+
+Command shape:
+
+```powershell
+python scripts\paper_worker.py collect --input candidates.json --dry-run
+python scripts\paper_worker.py collect --input candidates.json
+```
+
+The input file is either a single JSON object or an array of objects. `title` is required. Optional
+fields are:
+
+```text
+source_url or url
+pdf_url
+doi
+arxiv_id
+authors
+year
+venue
+summary_ja
+reason
+relevance_note
+priority
+tags
+source
+```
+
+Example:
+
+```json
+{
+  "title": "Example Paper",
+  "source_url": "https://doi.org/10.1234/example",
+  "pdf_url": "https://example.com/paper.pdf",
+  "authors": ["A. Researcher", "B. Author"],
+  "year": 2026,
+  "venue": "ExampleConf",
+  "summary_ja": "Short Japanese summary",
+  "reason": "Why this should be considered",
+  "relevance_note": "How this connects to the reading list",
+  "priority": "Medium",
+  "tags": ["survey"],
+  "source": "manual"
+}
+```
+
+Created Notion cards use `Status = Inbox`. `Paper Key` is generated from the first available stable
+identifier in this order: DOI, arXiv ID, Source URL, then title.
+
+Duplicate policy:
+
+- Before creating cards, `collect` indexes existing Notion pages.
+- It skips candidates that match an existing page by DOI, arXiv ID, Source URL, Paper Key, or Title.
+- It also adds each planned or created candidate to the in-memory index, so duplicates inside one
+  input file are skipped.
+- `--dry-run` still performs the duplicate check, prints `would collect` for planned cards, and
+  prints `skipped duplicate` for skipped cards without creating Notion pages.

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -890,10 +890,14 @@ def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
 
 
 def collect_page_duplicate_keys(page: dict[str, Any]) -> list[tuple[str, str]]:
+    source_url = get_text(page, "Source URL")
+    doi = extract_doi(get_text(page, "DOI"), source_url)
+    if not doi:
+        doi = normalize_collect_string(get_text(page, "DOI"))
     record = {
-        "doi": get_text(page, "DOI"),
-        "arxiv_id": get_text(page, "arXiv ID"),
-        "source_url": get_text(page, "Source URL"),
+        "doi": doi,
+        "arxiv_id": normalize_collect_arxiv_id(get_text(page, "arXiv ID"), source_url),
+        "source_url": source_url,
         "paper_key": get_text(page, "Paper Key"),
         "title": get_title(page),
     }

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -769,6 +769,10 @@ def validate_select_option_name(value: str, field_name: str) -> None:
         raise PaperWorkerError(f"{field_name} must not contain commas: {value}")
 
 
+def normalize_collect_doi(value: Any, *fallback_values: str) -> str:
+    return extract_doi(normalize_collect_string(value), *fallback_values)
+
+
 def normalize_collect_arxiv_id(value: Any, *fallback_values: str) -> str:
     text = normalize_collect_string(value)
     arxiv = extract_arxiv(text, *fallback_values)
@@ -808,10 +812,8 @@ def collect_record(raw: dict[str, Any]) -> dict[str, Any]:
     title = normalize_collect_string(raw.get("title"))
     source_url = first_url(normalize_collect_string(raw.get("source_url") or raw.get("url")))
     pdf_url = first_url(normalize_collect_string(raw.get("pdf_url")))
-    doi = extract_doi(normalize_collect_string(raw.get("doi")), source_url, pdf_url)
+    doi = normalize_collect_doi(raw.get("doi"), source_url, pdf_url)
     arxiv = normalize_collect_arxiv_id(raw.get("arxiv_id"), source_url, pdf_url)
-    if not doi:
-        doi = normalize_collect_string(raw.get("doi"))
 
     record: dict[str, Any] = {
         "title": title,
@@ -903,11 +905,8 @@ def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
 
 def collect_page_duplicate_keys(page: dict[str, Any]) -> list[tuple[str, str]]:
     source_url = get_text(page, "Source URL")
-    doi = extract_doi(get_text(page, "DOI"), source_url)
-    if not doi:
-        doi = normalize_collect_string(get_text(page, "DOI"))
     record = {
-        "doi": doi,
+        "doi": normalize_collect_doi(get_text(page, "DOI"), source_url),
         "arxiv_id": normalize_collect_arxiv_id(get_text(page, "arXiv ID"), source_url),
         "source_url": source_url,
         "paper_key": get_text(page, "Paper Key"),

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -841,7 +841,8 @@ def collect_paper_key(record: dict[str, Any]) -> str:
     if record.get("arxiv_id"):
         return "arxiv-" + slugify(record["arxiv_id"])
     if record.get("source_url"):
-        return "url-" + slugify(record["source_url"])
+        url_hash = hashlib.sha1(record["source_url"].encode("utf-8")).hexdigest()[:8]
+        return f"url-{slugify(record['source_url'])}-{url_hash}"
     return "title-" + slugify(record["title"])
 
 
@@ -883,8 +884,9 @@ def collect_record_to_properties(record: dict[str, Any]) -> dict[str, Any]:
     return properties
 
 
-def normalize_duplicate_value(value: str) -> str:
-    return re.sub(r"\s+", " ", (value or "").strip()).lower()
+def normalize_duplicate_value(value: str, *, case_sensitive: bool = False) -> str:
+    normalized = re.sub(r"\s+", " ", (value or "").strip())
+    return normalized if case_sensitive else normalized.lower()
 
 
 def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
@@ -897,7 +899,7 @@ def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
     ]
     keys: list[tuple[str, str]] = []
     for label, value in candidates:
-        normalized = normalize_duplicate_value(value)
+        normalized = normalize_duplicate_value(value, case_sensitive=label == "Source URL")
         if normalized:
             keys.append((label, f"{label}:{normalized}"))
     return keys
@@ -905,9 +907,10 @@ def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
 
 def collect_page_duplicate_keys(page: dict[str, Any]) -> list[tuple[str, str]]:
     source_url = get_text(page, "Source URL")
+    pdf_url = get_text(page, "PDF URL")
     record = {
-        "doi": normalize_collect_doi(get_text(page, "DOI"), source_url),
-        "arxiv_id": normalize_collect_arxiv_id(get_text(page, "arXiv ID"), source_url),
+        "doi": normalize_collect_doi(get_text(page, "DOI"), source_url, pdf_url),
+        "arxiv_id": normalize_collect_arxiv_id(get_text(page, "arXiv ID"), source_url, pdf_url),
         "source_url": source_url,
         "paper_key": get_text(page, "Paper Key"),
         "title": get_title(page),

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -627,7 +627,7 @@ def parse_issue_body(body: str) -> dict[str, Any]:
 
 
 def first_url(value: str) -> str:
-    match = re.search(r"https?://\S+", value or "")
+    match = re.search(r"https?://\S+", value or "", flags=re.I)
     if not match:
         return ""
     url = match.group(0)
@@ -786,8 +786,8 @@ def normalize_url_scheme_and_host(value: str) -> str:
 
 def normalize_collect_source_url(value: Any) -> str:
     raw_text = normalize_collect_string(value)
-    text = first_url(raw_text) or raw_text
-    return normalize_url_scheme_and_host(text)
+    text = first_url(raw_text)
+    return normalize_url_scheme_and_host(text) if text else ""
 
 
 def normalize_collect_doi(value: Any, *fallback_values: str) -> str:

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -769,6 +769,27 @@ def validate_select_option_name(value: str, field_name: str) -> None:
         raise PaperWorkerError(f"{field_name} must not contain commas: {value}")
 
 
+def normalize_url_scheme_and_host(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    if not parsed.scheme or not parsed.netloc:
+        return value
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def normalize_collect_source_url(value: Any) -> str:
+    raw_text = normalize_collect_string(value)
+    text = first_url(raw_text) or raw_text
+    return normalize_url_scheme_and_host(text)
+
+
 def normalize_collect_doi(value: Any, *fallback_values: str) -> str:
     return extract_doi(normalize_collect_string(value), *fallback_values)
 
@@ -810,7 +831,7 @@ def load_collect_input(path: Path) -> list[dict[str, Any]]:
 
 def collect_record(raw: dict[str, Any]) -> dict[str, Any]:
     title = normalize_collect_string(raw.get("title"))
-    source_url = first_url(normalize_collect_string(raw.get("source_url") or raw.get("url")))
+    source_url = normalize_collect_source_url(raw.get("source_url") or raw.get("url"))
     pdf_url = first_url(normalize_collect_string(raw.get("pdf_url")))
     doi = normalize_collect_doi(raw.get("doi"), source_url, pdf_url)
     arxiv = normalize_collect_arxiv_id(raw.get("arxiv_id"), source_url, pdf_url)
@@ -841,8 +862,9 @@ def collect_paper_key(record: dict[str, Any]) -> str:
     if record.get("arxiv_id"):
         return "arxiv-" + slugify(record["arxiv_id"])
     if record.get("source_url"):
-        url_hash = hashlib.sha1(record["source_url"].encode("utf-8")).hexdigest()[:8]
-        return f"url-{slugify(record['source_url'])}-{url_hash}"
+        source_url_key = normalize_source_url_duplicate_value(record["source_url"])
+        url_hash = hashlib.sha1(source_url_key.encode("utf-8")).hexdigest()[:8]
+        return f"url-{slugify(source_url_key)}-{url_hash}"
     return "title-" + slugify(record["title"])
 
 
@@ -889,6 +911,11 @@ def normalize_duplicate_value(value: str, *, case_sensitive: bool = False) -> st
     return normalized if case_sensitive else normalized.lower()
 
 
+def normalize_source_url_duplicate_value(value: str) -> str:
+    normalized = normalize_duplicate_value(value, case_sensitive=True)
+    return normalize_url_scheme_and_host(normalized)
+
+
 def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
     candidates = [
         ("DOI", record.get("doi", "")),
@@ -899,14 +926,17 @@ def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
     ]
     keys: list[tuple[str, str]] = []
     for label, value in candidates:
-        normalized = normalize_duplicate_value(value, case_sensitive=label == "Source URL")
+        if label == "Source URL":
+            normalized = normalize_source_url_duplicate_value(value)
+        else:
+            normalized = normalize_duplicate_value(value)
         if normalized:
             keys.append((label, f"{label}:{normalized}"))
     return keys
 
 
 def collect_page_duplicate_keys(page: dict[str, Any]) -> list[tuple[str, str]]:
-    source_url = get_text(page, "Source URL")
+    source_url = normalize_collect_source_url(get_text(page, "Source URL"))
     pdf_url = get_text(page, "PDF URL")
     record = {
         "doi": normalize_collect_doi(get_text(page, "DOI"), source_url, pdf_url),

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -759,7 +759,14 @@ def normalize_collect_list(value: Any) -> list[str]:
     if isinstance(value, list):
         return [normalize_collect_string(item) for item in value if normalize_collect_string(item)]
     text = normalize_collect_string(value)
+    if "," in text:
+        return [item.strip() for item in text.split(",") if item.strip()]
     return [text] if text else []
+
+
+def validate_select_option_name(value: str, field_name: str) -> None:
+    if "," in value:
+        raise PaperWorkerError(f"{field_name} must not contain commas: {value}")
 
 
 def normalize_collect_arxiv_id(value: Any, *fallback_values: str) -> str:
@@ -837,6 +844,11 @@ def collect_paper_key(record: dict[str, Any]) -> str:
 
 
 def collect_record_to_properties(record: dict[str, Any]) -> dict[str, Any]:
+    if record.get("priority"):
+        validate_select_option_name(record["priority"], "priority")
+    for tag in record.get("tags", []):
+        validate_select_option_name(tag, "tags")
+
     properties: dict[str, Any] = {
         "Title": title_value(record["title"]),
         "Status": status_value("Inbox"),

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -745,6 +745,215 @@ def issue_to_properties(repo: str, issue: dict[str, Any]) -> dict[str, Any]:
     return properties
 
 
+def normalize_collect_string(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def normalize_collect_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [normalize_collect_string(item) for item in value if normalize_collect_string(item)]
+    text = normalize_collect_string(value)
+    return [text] if text else []
+
+
+def normalize_collect_arxiv_id(value: Any, *fallback_values: str) -> str:
+    text = normalize_collect_string(value)
+    arxiv = extract_arxiv(text, *fallback_values)
+    if arxiv:
+        return arxiv
+    match = re.fullmatch(r"(\d{4}\.\d{4,5})(?:v\d+)?", text, flags=re.I)
+    return match.group(1) if match else text
+
+
+def load_collect_input(path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise PaperWorkerError(f"Could not read collect input: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PaperWorkerError(f"Collect input must be JSON: {exc}") from exc
+
+    if isinstance(data, dict):
+        items = [data]
+    elif isinstance(data, list):
+        items = data
+    else:
+        raise PaperWorkerError("Collect input must be an object or an array of objects")
+
+    records: list[dict[str, Any]] = []
+    for index, item in enumerate(items, start=1):
+        if not isinstance(item, dict):
+            raise PaperWorkerError(f"Collect item #{index} must be an object")
+        title = normalize_collect_string(item.get("title"))
+        if not title:
+            raise PaperWorkerError(f"Collect item #{index} is missing required field: title")
+        records.append(item)
+    return records
+
+
+def collect_record(raw: dict[str, Any]) -> dict[str, Any]:
+    title = normalize_collect_string(raw.get("title"))
+    source_url = first_url(normalize_collect_string(raw.get("source_url") or raw.get("url")))
+    pdf_url = first_url(normalize_collect_string(raw.get("pdf_url")))
+    doi = extract_doi(normalize_collect_string(raw.get("doi")), source_url, pdf_url)
+    arxiv = normalize_collect_arxiv_id(raw.get("arxiv_id"), source_url, pdf_url)
+    if not doi:
+        doi = normalize_collect_string(raw.get("doi"))
+
+    record: dict[str, Any] = {
+        "title": title,
+        "source_url": source_url,
+        "pdf_url": pdf_url,
+        "doi": doi,
+        "arxiv_id": arxiv,
+        "authors": ", ".join(normalize_collect_list(raw.get("authors"))),
+        "year": normalize_year(normalize_collect_string(raw.get("year"))),
+        "venue": normalize_collect_string(raw.get("venue")),
+        "summary_ja": normalize_collect_string(raw.get("summary_ja")),
+        "reason": normalize_collect_string(raw.get("reason")),
+        "relevance_note": normalize_collect_string(raw.get("relevance_note")),
+        "priority": normalize_collect_string(raw.get("priority")),
+        "tags": normalize_collect_list(raw.get("tags"))[:20],
+        "source": normalize_collect_string(raw.get("source")),
+    }
+    record["paper_key"] = collect_paper_key(record)
+    return record
+
+
+def collect_paper_key(record: dict[str, Any]) -> str:
+    if record.get("doi"):
+        return "doi-" + slugify(record["doi"])
+    if record.get("arxiv_id"):
+        return "arxiv-" + slugify(record["arxiv_id"])
+    if record.get("source_url"):
+        return "url-" + slugify(record["source_url"])
+    return "title-" + slugify(record["title"])
+
+
+def collect_record_to_properties(record: dict[str, Any]) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        "Title": title_value(record["title"]),
+        "Status": status_value("Inbox"),
+        "Paper Key": rich_text(record["paper_key"]),
+    }
+    optional_rich_text_fields = {
+        "DOI": "doi",
+        "arXiv ID": "arxiv_id",
+        "Authors": "authors",
+        "Venue": "venue",
+        "Short Summary JA": "summary_ja",
+        "Reason": "reason",
+        "Relevance Note": "relevance_note",
+        "Source": "source",
+    }
+    for property_name, record_key in optional_rich_text_fields.items():
+        value = record.get(record_key)
+        if value:
+            properties[property_name] = rich_text(value)
+    if record.get("source_url"):
+        properties["Source URL"] = url_value(record["source_url"])
+    if record.get("pdf_url"):
+        properties["PDF URL"] = url_value(record["pdf_url"])
+    if record.get("year") is not None:
+        properties["Year"] = number_value(record["year"])
+    if record.get("priority"):
+        properties["Priority"] = select(record["priority"])
+    if record.get("tags"):
+        properties["Tags"] = multi_select(record["tags"])
+    return properties
+
+
+def normalize_duplicate_value(value: str) -> str:
+    return re.sub(r"\s+", " ", (value or "").strip()).lower()
+
+
+def collect_duplicate_keys(record: dict[str, Any]) -> list[tuple[str, str]]:
+    candidates = [
+        ("DOI", record.get("doi", "")),
+        ("arXiv ID", record.get("arxiv_id", "")),
+        ("Source URL", record.get("source_url", "")),
+        ("Paper Key", record.get("paper_key", "")),
+        ("Title", record.get("title", "")),
+    ]
+    keys: list[tuple[str, str]] = []
+    for label, value in candidates:
+        normalized = normalize_duplicate_value(value)
+        if normalized:
+            keys.append((label, f"{label}:{normalized}"))
+    return keys
+
+
+def collect_page_duplicate_keys(page: dict[str, Any]) -> list[tuple[str, str]]:
+    record = {
+        "doi": get_text(page, "DOI"),
+        "arxiv_id": get_text(page, "arXiv ID"),
+        "source_url": get_text(page, "Source URL"),
+        "paper_key": get_text(page, "Paper Key"),
+        "title": get_title(page),
+    }
+    return collect_duplicate_keys(record)
+
+
+def collect_duplicate_index() -> dict[str, dict[str, Any]]:
+    pages = query_database(page_size=100)
+    index: dict[str, dict[str, Any]] = {}
+    for page in pages:
+        for _, key in collect_page_duplicate_keys(page):
+            index.setdefault(key, page)
+    return index
+
+
+def collect_duplicate_reason(record: dict[str, Any], index: dict[str, dict[str, Any]]) -> str:
+    for label, key in collect_duplicate_keys(record):
+        if key in index:
+            return label
+    return ""
+
+
+def add_collect_record_to_index(
+    index: dict[str, dict[str, Any]],
+    record: dict[str, Any],
+    page: dict[str, Any] | None = None,
+) -> None:
+    marker = page or {"id": f"collect:{record['paper_key']}", "properties": {}}
+    for _, key in collect_duplicate_keys(record):
+        index.setdefault(key, marker)
+
+
+def command_collect(args: argparse.Namespace) -> int:
+    raw_items = load_collect_input(Path(args.input))
+    index = collect_duplicate_index()
+    created = 0
+    skipped = 0
+
+    for raw_item in raw_items:
+        record = collect_record(raw_item)
+        duplicate_reason = collect_duplicate_reason(record, index)
+        if duplicate_reason:
+            print(f"skipped duplicate ({duplicate_reason}): {record['title']}")
+            skipped += 1
+            continue
+
+        properties = collect_record_to_properties(record)
+        if args.dry_run:
+            print(f"would collect: {record['title']} [{record['paper_key']}]")
+        else:
+            create_page(properties)
+            print(f"collected: {record['title']} [{record['paper_key']}]")
+        add_collect_record_to_index(index, record)
+        created += 1
+
+    action = "would_create" if args.dry_run else "created"
+    print(f"done: {action}={created} skipped={skipped}")
+    return 0
+
+
 def github_issues(repo: str, limit: int) -> list[dict[str, Any]]:
     encoded_repo = urllib.parse.quote(repo, safe="/")
     issues: list[dict[str, Any]] = []
@@ -980,6 +1189,11 @@ def build_parser() -> argparse.ArgumentParser:
     prepare.add_argument("--skip-download", action="store_true")
     prepare.add_argument("--keep-going", action="store_true")
     prepare.set_defaults(func=command_prepare)
+
+    collect = subparsers.add_parser("collect", help="Collect candidate papers into Notion Inbox")
+    collect.add_argument("--input", required=True, help="Path to a JSON object or array of objects")
+    collect.add_argument("--dry-run", action="store_true", help="Print planned creates and duplicate skips")
+    collect.set_defaults(func=command_collect)
 
     import_issues = subparsers.add_parser("import-github-issues", help="Import GitHub issues into Notion")
     import_issues.add_argument("--repo", default=None)

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -865,7 +865,12 @@ def collect_paper_key(record: dict[str, Any]) -> str:
         source_url_key = normalize_source_url_duplicate_value(record["source_url"])
         url_hash = hashlib.sha1(source_url_key.encode("utf-8")).hexdigest()[:8]
         return f"url-{slugify(source_url_key)}-{url_hash}"
-    return "title-" + slugify(record["title"])
+    title = record["title"]
+    title_slug = slugify(title)
+    if title_slug == "paper" and normalize_collect_string(title).lower() != "paper":
+        title_hash = hashlib.sha1(title.encode("utf-8")).hexdigest()[:8]
+        return f"title-{title_slug}-{title_hash}"
+    return "title-" + title_slug
 
 
 def collect_record_to_properties(record: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -779,7 +779,7 @@ def normalize_collect_arxiv_id(value: Any, *fallback_values: str) -> str:
     if arxiv:
         return arxiv
     match = re.fullmatch(r"(\d{4}\.\d{4,5})(?:v\d+)?", text, flags=re.I)
-    return match.group(1) if match else text
+    return match.group(1) if match else ""
 
 
 def load_collect_input(path: Path) -> list[dict[str, Any]]:

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -831,7 +831,9 @@ def load_collect_input(path: Path) -> list[dict[str, Any]]:
 
 def collect_record(raw: dict[str, Any]) -> dict[str, Any]:
     title = normalize_collect_string(raw.get("title"))
-    source_url = normalize_collect_source_url(raw.get("source_url") or raw.get("url"))
+    source_url = normalize_collect_source_url(raw.get("source_url"))
+    if not source_url:
+        source_url = normalize_collect_source_url(raw.get("url"))
     pdf_url = first_url(normalize_collect_string(raw.get("pdf_url")))
     doi = normalize_collect_doi(raw.get("doi"), source_url, pdf_url)
     arxiv = normalize_collect_arxiv_id(raw.get("arxiv_id"), source_url, pdf_url)

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -546,6 +546,69 @@ class CollectCommandTests(unittest.TestCase):
         create_page.assert_not_called()
         self.assertIn("skipped duplicate (arXiv ID): Duplicate Paper", stdout.getvalue())
 
+    def test_collect_preserves_source_url_path_case_for_duplicate_key(self):
+        args, input_patch = self.collect_args(
+            [
+                {"title": "Upper Path", "source_url": "https://example.test/Paper"},
+                {"title": "Lower Path", "source_url": "https://example.test/paper"},
+            ]
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: Upper Path [url-example.test-paper-", stdout.getvalue())
+        self.assertIn("would collect: Lower Path [url-example.test-paper-", stdout.getvalue())
+        self.assertIn("done: would_create=2 skipped=0", stdout.getvalue())
+
+    def test_collect_uses_existing_pdf_url_for_arxiv_duplicate(self):
+        args, input_patch = self.collect_args({"title": "Duplicate PDF URL", "arxiv_id": "2601.00630"})
+
+        with (
+            input_patch,
+            patch.object(
+                paper_worker,
+                "query_database",
+                return_value=[collect_page("Existing", **{"PDF URL": "https://arxiv.org/pdf/2601.00630v2"})],
+            ),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (arXiv ID): Duplicate PDF URL", stdout.getvalue())
+
+    def test_collect_uses_existing_pdf_url_for_doi_duplicate(self):
+        args, input_patch = self.collect_args({"title": "Duplicate DOI PDF URL", "doi": "10.5555/example"})
+
+        with (
+            input_patch,
+            patch.object(
+                paper_worker,
+                "query_database",
+                return_value=[collect_page("Existing", **{"PDF URL": "https://doi.org/10.5555/example"})],
+            ),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (DOI): Duplicate DOI PDF URL", stdout.getvalue())
+
     def test_collect_skips_existing_title_duplicate(self):
         args, input_patch = self.collect_args({"title": "Known Paper"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -486,6 +486,46 @@ class CollectCommandTests(unittest.TestCase):
         self.assertIn("would collect: New Placeholder DOI [title-new-placeholder-doi]", stdout.getvalue())
         self.assertIn("done: would_create=1 skipped=0", stdout.getvalue())
 
+    def test_collect_ignores_placeholder_arxiv_for_duplicate_key(self):
+        args, input_patch = self.collect_args(
+            [
+                {"title": "First Placeholder arXiv", "arxiv_id": "N/A"},
+                {"title": "Second Placeholder arXiv", "arxiv_id": "unknown"},
+            ]
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: First Placeholder arXiv [title-first-placeholder-arxiv]", stdout.getvalue())
+        self.assertIn("would collect: Second Placeholder arXiv [title-second-placeholder-arxiv]", stdout.getvalue())
+        self.assertIn("done: would_create=2 skipped=0", stdout.getvalue())
+
+    def test_collect_ignores_existing_placeholder_arxiv(self):
+        args, input_patch = self.collect_args({"title": "New Placeholder arXiv", "arxiv_id": "N/A"})
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[collect_page("Existing", **{"arXiv ID": "N/A"})]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: New Placeholder arXiv [title-new-placeholder-arxiv]", stdout.getvalue())
+        self.assertIn("done: would_create=1 skipped=0", stdout.getvalue())
+
     def test_collect_skips_existing_arxiv_version_duplicate(self):
         args, input_patch = self.collect_args({"title": "Duplicate Paper", "arxiv_id": "2601.00630"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -367,6 +367,48 @@ class CollectCommandTests(unittest.TestCase):
         self.assertEqual(properties["Priority"], {"select": {"name": "High"}})
         self.assertEqual(properties["Tags"], {"multi_select": [{"name": "llm"}]})
 
+    def test_collect_splits_comma_separated_tags(self):
+        args, input_patch = self.collect_args(
+            {
+                "title": "Tagged Paper",
+                "tags": "survey, llm",
+            },
+            dry_run=False,
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        properties = create_page.call_args.args[0]
+        self.assertEqual(properties["Tags"], {"multi_select": [{"name": "survey"}, {"name": "llm"}]})
+
+    def test_collect_rejects_comma_in_priority_before_create(self):
+        args, input_patch = self.collect_args(
+            {
+                "title": "Invalid Priority",
+                "priority": "High,urgent",
+            },
+            dry_run=False,
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+        ):
+            with self.assertRaisesRegex(paper_worker.PaperWorkerError, "priority must not contain commas"):
+                paper_worker.command_collect(args)
+
+        create_page.assert_not_called()
+
     def test_collect_skips_existing_doi_duplicate(self):
         args, input_patch = self.collect_args({"title": "Duplicate Paper", "doi": "10.5555/example"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -1,5 +1,6 @@
 import argparse
 import io
+import json
 import os
 import unittest
 from pathlib import Path
@@ -21,6 +22,19 @@ def notion_page(issue_number, issue_url="", status="", status_type="select"):
             "Status": status_property,
         },
     }
+
+
+def collect_page(title, **fields):
+    properties = {
+        "Title": {"type": "title", "title": [{"plain_text": title}]},
+        "Status": {"type": "select", "select": {"name": "Inbox"}},
+    }
+    for name, value in fields.items():
+        if name == "Source URL":
+            properties[name] = {"type": "url", "url": value}
+        else:
+            properties[name] = {"type": "rich_text", "rich_text": [{"plain_text": value}]}
+    return {"id": f"page-{paper_worker.slugify(title)}", "properties": properties}
 
 
 class GitHubIssueResolutionTests(unittest.TestCase):
@@ -271,6 +285,141 @@ class IssueImportParsingTests(unittest.TestCase):
             properties["Paper Key"],
             {"rich_text": [{"type": "text", "text": {"content": "github-owner-repo-issue-9"}}]},
         )
+
+
+class CollectCommandTests(unittest.TestCase):
+    def collect_args(self, payload, dry_run=True):
+        records = payload if isinstance(payload, list) else [payload]
+        return (
+            argparse.Namespace(input="collect.json", dry_run=dry_run),
+            patch.object(paper_worker, "load_collect_input", return_value=records),
+        )
+
+    def test_collect_parser_registers_command(self):
+        args = paper_worker.build_parser().parse_args(["collect", "--input", "papers.json", "--dry-run"])
+
+        self.assertIs(args.func, paper_worker.command_collect)
+        self.assertEqual(args.input, "papers.json")
+        self.assertTrue(args.dry_run)
+
+    def test_collect_dry_run_prints_planned_card_without_creating(self):
+        args, input_patch = self.collect_args(
+            {
+                "title": "A Useful Paper",
+                "source_url": "https://doi.org/10.1234/example",
+                "tags": ["reading-list", "survey"],
+            }
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: A Useful Paper [doi-10.1234-example]", stdout.getvalue())
+        self.assertIn("done: would_create=1 skipped=0", stdout.getvalue())
+
+    def test_collect_creates_inbox_card_properties(self):
+        args, input_patch = self.collect_args(
+            {
+                "title": "Collected Paper",
+                "url": "https://example.com/collected-paper",
+                "pdf_url": "https://arxiv.org/pdf/2601.00630v2",
+                "arxiv_id": "2601.00630v2",
+                "authors": "A. Researcher",
+                "year": "2026",
+                "venue": "ExampleConf",
+                "summary_ja": "Short summary",
+                "reason": "Looks relevant",
+                "relevance_note": "Matches the project",
+                "priority": "High",
+                "tags": ["llm"],
+                "source": "manual",
+            },
+            dry_run=False,
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_called_once()
+        properties = create_page.call_args.args[0]
+        self.assertEqual(properties["Title"], {"title": [{"type": "text", "text": {"content": "Collected Paper"}}]})
+        self.assertEqual(properties["Status"], {"select": {"name": "Inbox"}})
+        self.assertEqual(properties["Paper Key"], {"rich_text": [{"type": "text", "text": {"content": "arxiv-2601.00630"}}]})
+        self.assertEqual(properties["Source URL"], {"url": "https://example.com/collected-paper"})
+        self.assertEqual(properties["PDF URL"], {"url": "https://arxiv.org/pdf/2601.00630v2"})
+        self.assertEqual(properties["arXiv ID"], {"rich_text": [{"type": "text", "text": {"content": "2601.00630"}}]})
+        self.assertEqual(properties["Year"], {"number": 2026})
+        self.assertEqual(properties["Priority"], {"select": {"name": "High"}})
+        self.assertEqual(properties["Tags"], {"multi_select": [{"name": "llm"}]})
+
+    def test_collect_skips_existing_doi_duplicate(self):
+        args, input_patch = self.collect_args({"title": "Duplicate Paper", "doi": "10.5555/example"})
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[collect_page("Existing", DOI="10.5555/example")]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (DOI): Duplicate Paper", stdout.getvalue())
+        self.assertIn("done: would_create=0 skipped=1", stdout.getvalue())
+
+    def test_collect_skips_existing_title_duplicate(self):
+        args, input_patch = self.collect_args({"title": "Known Paper"})
+
+        with (
+            input_patch,
+            patch.object(
+                paper_worker,
+                "query_database",
+                return_value=[collect_page("Known   Paper", **{"Paper Key": "legacy-key"})],
+            ),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (Title): Known Paper", stdout.getvalue())
+
+    def test_collect_skips_duplicate_within_same_input_by_paper_key(self):
+        args, input_patch = self.collect_args([{"title": "Same Title"}, {"title": "Same  Title"}])
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: Same Title [title-same-title]", stdout.getvalue())
+        self.assertIn("skipped duplicate (Paper Key): Same  Title", stdout.getvalue())
 
 
 class ProjectItemUpdateTests(unittest.TestCase):

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -652,6 +652,29 @@ class CollectCommandTests(unittest.TestCase):
         create_page.assert_not_called()
         self.assertIn("skipped duplicate (DOI): Duplicate DOI PDF URL", stdout.getvalue())
 
+    def test_collect_uses_hash_for_non_ascii_title_only_paper_key(self):
+        args, input_patch = self.collect_args(
+            [
+                {"title": "日本語だけの候補"},
+                {"title": "別の日本語候補"},
+            ]
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: 日本語だけの候補 [title-paper-", stdout.getvalue())
+        self.assertIn("would collect: 別の日本語候補 [title-paper-", stdout.getvalue())
+        self.assertIn("done: would_create=2 skipped=0", stdout.getvalue())
+
     def test_collect_skips_existing_title_duplicate(self):
         args, input_patch = self.collect_args({"title": "Known Paper"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -446,6 +446,46 @@ class CollectCommandTests(unittest.TestCase):
         create_page.assert_not_called()
         self.assertIn("skipped duplicate (DOI): Duplicate Paper", stdout.getvalue())
 
+    def test_collect_ignores_placeholder_doi_for_duplicate_key(self):
+        args, input_patch = self.collect_args(
+            [
+                {"title": "First Placeholder DOI", "doi": "N/A"},
+                {"title": "Second Placeholder DOI", "doi": "unknown"},
+            ]
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: First Placeholder DOI [title-first-placeholder-doi]", stdout.getvalue())
+        self.assertIn("would collect: Second Placeholder DOI [title-second-placeholder-doi]", stdout.getvalue())
+        self.assertIn("done: would_create=2 skipped=0", stdout.getvalue())
+
+    def test_collect_ignores_existing_placeholder_doi(self):
+        args, input_patch = self.collect_args({"title": "New Placeholder DOI", "doi": "N/A"})
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[collect_page("Existing", DOI="N/A")]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: New Placeholder DOI [title-new-placeholder-doi]", stdout.getvalue())
+        self.assertIn("done: would_create=1 skipped=0", stdout.getvalue())
+
     def test_collect_skips_existing_arxiv_version_duplicate(self):
         args, input_patch = self.collect_args({"title": "Duplicate Paper", "arxiv_id": "2601.00630"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -549,6 +549,32 @@ class CollectCommandTests(unittest.TestCase):
         self.assertIn("would collect: Second Placeholder URL [title-second-placeholder-url]", stdout.getvalue())
         self.assertIn("done: would_create=2 skipped=0", stdout.getvalue())
 
+    def test_collect_falls_back_to_url_when_source_url_is_placeholder(self):
+        args, input_patch = self.collect_args(
+            {
+                "title": "Fallback URL",
+                "source_url": "N/A",
+                "url": "https://example.test/fallback-paper",
+            }
+        )
+
+        with (
+            input_patch,
+            patch.object(
+                paper_worker,
+                "query_database",
+                return_value=[collect_page("Existing", **{"Source URL": "https://example.test/fallback-paper"})],
+            ),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (Source URL): Fallback URL", stdout.getvalue())
+
     def test_collect_skips_existing_arxiv_version_duplicate(self):
         args, input_patch = self.collect_args({"title": "Duplicate Paper", "arxiv_id": "2601.00630"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -569,6 +569,26 @@ class CollectCommandTests(unittest.TestCase):
         self.assertIn("would collect: Lower Path [url-example.test-paper-", stdout.getvalue())
         self.assertIn("done: would_create=2 skipped=0", stdout.getvalue())
 
+    def test_collect_normalizes_source_url_scheme_and_host_case_for_duplicate_key(self):
+        args, input_patch = self.collect_args({"title": "Duplicate Host Case", "source_url": "https://example.test/paper"})
+
+        with (
+            input_patch,
+            patch.object(
+                paper_worker,
+                "query_database",
+                return_value=[collect_page("Existing", **{"Source URL": "HTTPS://EXAMPLE.TEST/paper"})],
+            ),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (Source URL): Duplicate Host Case", stdout.getvalue())
+
     def test_collect_uses_existing_pdf_url_for_arxiv_duplicate(self):
         args, input_patch = self.collect_args({"title": "Duplicate PDF URL", "arxiv_id": "2601.00630"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -526,6 +526,29 @@ class CollectCommandTests(unittest.TestCase):
         self.assertIn("would collect: New Placeholder arXiv [title-new-placeholder-arxiv]", stdout.getvalue())
         self.assertIn("done: would_create=1 skipped=0", stdout.getvalue())
 
+    def test_collect_ignores_placeholder_source_url_for_duplicate_key(self):
+        args, input_patch = self.collect_args(
+            [
+                {"title": "First Placeholder URL", "source_url": "N/A"},
+                {"title": "Second Placeholder URL", "source_url": "unknown"},
+            ]
+        )
+
+        with (
+            input_patch,
+            patch.object(paper_worker, "query_database", return_value=[]),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("would collect: First Placeholder URL [title-first-placeholder-url]", stdout.getvalue())
+        self.assertIn("would collect: Second Placeholder URL [title-second-placeholder-url]", stdout.getvalue())
+        self.assertIn("done: would_create=2 skipped=0", stdout.getvalue())
+
     def test_collect_skips_existing_arxiv_version_duplicate(self):
         args, input_patch = self.collect_args({"title": "Duplicate Paper", "arxiv_id": "2601.00630"})
 

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -384,6 +384,46 @@ class CollectCommandTests(unittest.TestCase):
         self.assertIn("skipped duplicate (DOI): Duplicate Paper", stdout.getvalue())
         self.assertIn("done: would_create=0 skipped=1", stdout.getvalue())
 
+    def test_collect_skips_existing_doi_url_duplicate(self):
+        args, input_patch = self.collect_args({"title": "Duplicate Paper", "doi": "10.5555/example"})
+
+        with (
+            input_patch,
+            patch.object(
+                paper_worker,
+                "query_database",
+                return_value=[collect_page("Existing", DOI="https://doi.org/10.5555/example")],
+            ),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (DOI): Duplicate Paper", stdout.getvalue())
+
+    def test_collect_skips_existing_arxiv_version_duplicate(self):
+        args, input_patch = self.collect_args({"title": "Duplicate Paper", "arxiv_id": "2601.00630"})
+
+        with (
+            input_patch,
+            patch.object(
+                paper_worker,
+                "query_database",
+                return_value=[collect_page("Existing", **{"arXiv ID": "2601.00630v2"})],
+            ),
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "create_page") as create_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_collect(args)
+
+        self.assertEqual(exit_code, 0)
+        create_page.assert_not_called()
+        self.assertIn("skipped duplicate (arXiv ID): Duplicate Paper", stdout.getvalue())
+
     def test_collect_skips_existing_title_duplicate(self):
         args, input_patch = self.collect_args({"title": "Known Paper"})
 


### PR DESCRIPTION
## 概要

- 候補論文 JSON から Notion の Inbox 論文カードを作成する paper-worker collect を追加しました。
- DOI / arXiv / Source URL / Paper Key / Title による重複スキップを追加しました。
- DOI / arXiv / Source URL / title-only Paper Key の表記ゆれ、placeholder 値、select / multi_select 入力の扱いをテストで固定しました。
- docs の CLI 実装状況でも collect を実装済みとして整理しました。

## 検証

- C:\Users\tomioka\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m unittest tests.test_paper_worker（60 tests OK）
- git diff --check（CRLF 警告のみ）

## Review

- intent review: PASS
- fresh pre PR review: PASS
- GitHub Codex review: 指摘対応後に再依頼中

## 外部状態の変更

- GitHub PR review comment へ妥当な指摘として +1 と返信を追加しました。
- Notion には接続・変更していません。

## 残リスク

- 実 Notion database への作成は dry-run / mock 中心で検証しています。

Closes #110