### PR TITLE
失敗した論文処理を再実行する retry --failed を追加する

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,6 +62,18 @@ Prepare papers:
 python scripts\paper_worker.py prepare
 ```
 
+Preview failed papers that would be retried:
+
+```powershell
+python scripts\paper_worker.py retry --failed --dry-run
+```
+
+Retry failed papers:
+
+```powershell
+python scripts\paper_worker.py retry --failed --keep-going
+```
+
 Show status counts:
 
 ```powershell
@@ -86,6 +98,7 @@ python scripts\paper_worker.py sync-github-project --owner owner --project-numbe
 ## Notes
 
 - The CLI currently creates the local folder, `metadata.json`, `notes.md`, and downloads `paper.pdf` when `PDF URL` is present.
+- `retry --failed` initially targets Notion cards with `Status = Error` and reuses the same preparation flow as `prepare`. It shows `Process Tags` in dry-run output, but does not yet dispatch separate recovery logic per tag.
 - GitHub Projects sync uses the GitHub CLI, so `gh` must be installed and authenticated with `project`.
 - Full text extraction and translation are planned next.
 - Notion IDs and tokens must stay in `.env` or another local-only configuration file.

--- a/docs/paper-reading-system-spec.md
+++ b/docs/paper-reading-system-spec.md
@@ -235,6 +235,19 @@ paper-worker status
 paper-worker show paper-id
 ```
 
+### `paper-worker retry --failed` の初期版方針
+
+`paper-worker retry --failed` は、Notion の `Status = Error` の論文カードを再実行対象にする。
+`--dry-run` では Notion 更新やローカル書き込みを行わず、`would retry: <title> (<Process Tags>)`
+の形式で対象と理由を表示する。
+
+初期版では `Process Tags` ごとに別の処理エンジンへ振り分けず、`pdf_download_failed`、
+`pdf_missing`、`needs_manual_check`、空タグのいずれも `prepare` と同じ準備処理を再利用する。
+再実行後の `Status`、`Process Tags`、`Error Message`、`Last Processed` は既存の準備処理が更新する。
+
+`--keep-going` を指定しない場合は最初の失敗で終了コード 1 として停止する。`--keep-going` を
+指定した場合は残りの対象を続行し、最後に 1 件でも失敗があれば終了コード 1 を返す。
+
 ユーザーが困った場合は、Codex に CLI の出力やログを確認させて修正を依頼する。
 
 ## エラー処理

--- a/scripts/paper_worker.py
+++ b/scripts/paper_worker.py
@@ -574,6 +574,39 @@ def command_prepare(args: argparse.Namespace) -> int:
     return 1 if failures else 0
 
 
+def retry_reason(page: dict[str, Any]) -> str:
+    tags = get_multi_select(page, "Process Tags")
+    if tags:
+        return ", ".join(tags)
+    return "no process tags"
+
+
+def command_retry(args: argparse.Namespace) -> int:
+    pages = query_database(
+        status_filter("Error"),
+        page_size=min(args.limit, 100),
+        max_results=args.limit,
+    )
+    if not pages:
+        print("No papers with Status = Error.")
+        return 0
+
+    failures = 0
+    for page in pages[: args.limit]:
+        title = get_title(page) or page["id"]
+        if args.dry_run:
+            print(f"would retry: {title} ({retry_reason(page)})")
+            continue
+        try:
+            print(prepare_page(page, dry_run=False, skip_download=args.skip_download))
+        except Exception as exc:
+            print(f"failed: {title}: {exc}", file=sys.stderr)
+            failures += 1
+            if not args.keep_going:
+                return 1
+    return 1 if failures else 0
+
+
 def command_status(args: argparse.Namespace) -> int:
     page_size = 100 if args.limit is None else min(args.limit, 100)
     pages = query_database(page_size=page_size, max_results=args.limit)
@@ -980,6 +1013,14 @@ def build_parser() -> argparse.ArgumentParser:
     prepare.add_argument("--skip-download", action="store_true")
     prepare.add_argument("--keep-going", action="store_true")
     prepare.set_defaults(func=command_prepare)
+
+    retry = subparsers.add_parser("retry", help="Retry failed paper processing")
+    retry.add_argument("--failed", action="store_true", required=True, help="Retry papers with Status = Error")
+    retry.add_argument("--limit", type=int, default=10)
+    retry.add_argument("--dry-run", action="store_true")
+    retry.add_argument("--skip-download", action="store_true")
+    retry.add_argument("--keep-going", action="store_true")
+    retry.set_defaults(func=command_retry)
 
     import_issues = subparsers.add_parser("import-github-issues", help="Import GitHub issues into Notion")
     import_issues.add_argument("--repo", default=None)

--- a/tests/test_paper_worker.py
+++ b/tests/test_paper_worker.py
@@ -9,16 +9,24 @@ import scripts.paper_worker as paper_worker
 from scripts.paper_worker import normalize_github_issue_url, resolve_notion_issue_page
 
 
-def notion_page(issue_number, issue_url="", status="", status_type="select"):
+def notion_page(issue_number, issue_url="", status="", status_type="select", title="", process_tags=None):
     status_property = {"type": "status", "status": {"name": status} if status else None}
     if status_type == "select":
         status_property = {"type": "select", "select": {"name": status} if status else None}
     return {
         "id": f"page-{issue_number}-{issue_url or 'missing'}",
         "properties": {
+            "Title": {
+                "type": "title",
+                "title": [{"plain_text": title}] if title else [],
+            },
             "GitHub Issue Number": {"type": "number", "number": issue_number},
             "GitHub Issue URL": {"type": "url", "url": issue_url or None},
             "Status": status_property,
+            "Process Tags": {
+                "type": "multi_select",
+                "multi_select": [{"name": tag} for tag in (process_tags or [])],
+            },
         },
     }
 
@@ -323,6 +331,138 @@ class PrepareCommandTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 1)
         self.assertEqual(prepare_page.call_count, 2)
+
+
+class RetryCommandTests(unittest.TestCase):
+    def test_retry_failed_uses_native_status_filter_when_schema_requires_it(self):
+        args = argparse.Namespace(
+            failed=True,
+            limit=2,
+            dry_run=True,
+            skip_download=False,
+            keep_going=False,
+        )
+
+        with (
+            patch.object(paper_worker, "database_property_type", return_value="status"),
+            patch.object(paper_worker, "query_database", return_value=[]) as query_database,
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            exit_code = paper_worker.command_retry(args)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            query_database.call_args.args[0],
+            {"property": "Status", "status": {"equals": "Error"}},
+        )
+
+    def test_retry_failed_dry_run_prints_retry_reason_without_preparing(self):
+        page = notion_page(
+            1,
+            status="Error",
+            title="Retryable Paper",
+            process_tags=["pdf_download_failed", "needs_manual_check"],
+        )
+        args = argparse.Namespace(
+            failed=True,
+            limit=10,
+            dry_run=True,
+            skip_download=False,
+            keep_going=False,
+        )
+
+        with (
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "query_database", return_value=[page]),
+            patch.object(paper_worker, "prepare_page") as prepare_page,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            exit_code = paper_worker.command_retry(args)
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "would retry: Retryable Paper (pdf_download_failed, needs_manual_check)",
+            stdout.getvalue(),
+        )
+        prepare_page.assert_not_called()
+
+    def test_retry_failed_executes_prepare_page_with_skip_download(self):
+        page = notion_page(1, status="Error")
+        args = argparse.Namespace(
+            failed=True,
+            limit=10,
+            dry_run=False,
+            skip_download=True,
+            keep_going=False,
+        )
+
+        with (
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "query_database", return_value=[page]),
+            patch.object(paper_worker, "prepare_page", return_value="prepared") as prepare_page,
+            patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            exit_code = paper_worker.command_retry(args)
+
+        self.assertEqual(exit_code, 0)
+        prepare_page.assert_called_once_with(page, dry_run=False, skip_download=True)
+
+    def test_retry_failed_stops_after_first_failure_without_keep_going(self):
+        pages = [notion_page(1, status="Error"), notion_page(2, status="Error")]
+        args = argparse.Namespace(
+            failed=True,
+            limit=10,
+            dry_run=False,
+            skip_download=False,
+            keep_going=False,
+        )
+
+        with (
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "query_database", return_value=pages),
+            patch.object(paper_worker, "prepare_page", side_effect=RuntimeError("boom")) as prepare_page,
+            patch("sys.stdout", new_callable=io.StringIO),
+            patch("sys.stderr", new_callable=io.StringIO),
+        ):
+            exit_code = paper_worker.command_retry(args)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(prepare_page.call_count, 1)
+
+    def test_retry_failed_keep_going_returns_failure_after_any_failed_item(self):
+        pages = [notion_page(1, status="Error"), notion_page(2, status="Error")]
+        args = argparse.Namespace(
+            failed=True,
+            limit=10,
+            dry_run=False,
+            skip_download=False,
+            keep_going=True,
+        )
+
+        with (
+            patch.object(paper_worker, "database_property_type", return_value="select"),
+            patch.object(paper_worker, "query_database", return_value=pages),
+            patch.object(paper_worker, "prepare_page", side_effect=[RuntimeError("boom"), "prepared"]) as prepare_page,
+            patch("sys.stdout", new_callable=io.StringIO),
+            patch("sys.stderr", new_callable=io.StringIO),
+        ):
+            exit_code = paper_worker.command_retry(args)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(prepare_page.call_count, 2)
+
+    def test_retry_parser_requires_failed_flag(self):
+        parser = paper_worker.build_parser()
+
+        with (
+            self.assertRaises(SystemExit),
+            patch("sys.stderr", new_callable=io.StringIO),
+        ):
+            parser.parse_args(["retry"])
+
+        args = parser.parse_args(["retry", "--failed", "--dry-run"])
+        self.assertTrue(args.failed)
+        self.assertIs(args.func, paper_worker.command_retry)
 
 
 class PreparePageTests(unittest.TestCase):


### PR DESCRIPTION
## 概要

- paper-worker retry --failed を追加しました。
- --dry-run / --limit / --keep-going / --skip-download に対応しました。
- Status = Error の Notion カードを対象にし、dry-run では対象タイトルと Process Tags 由来の理由を表示します。
- 実行時は既存の prepare_page() を再利用し、成功/失敗時の Status / Process Tags / Error Message / Last Processed 更新も既存 prepare flow に揃えます。
- 初期版では Process Tags ごとの個別分岐はせず、docs に方針を明記しました。

## 対応 Issue

Closes #113

## 検証

- C:\\Users\\tomioka\\.cache\\codex-runtimes\\codex-primary-runtime\\dependencies\\python\\python.exe -m unittest tests.test_paper_worker（45 tests OK）
- git diff --check（CRLF 変換警告のみ）
- intent review: pass
- fresh pre PR review: pass
- Notion database ID / token / private data / 個人ローカルパスの混入なしを確認

## 残リスク

- Process Tags ごとの本格的な再実行分岐は未実装です。今回の初期版では prepare と同じ準備処理を再利用します。

## Codex review

PR 作成後に @codex review を依頼します。