### PR TITLE
置き換えPRのclosing reference運用を明文化する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,23 @@ remaining risks, and closing issue references. Keep command names, file paths,
 environment variable names, and exact tool output snippets in their original
 literal form.
 
+## Replacement Pull Requests
+
+複数 PR の内容を統合した置き換え PR を作る場合は、置き換え元 PR を本文に明記する。
+
+本文には以下のような節を置き、merge 時に GitHub が対象 PR / Issue を自動 close できるよう closing reference を書く。
+
+```markdown
+## 置き換える PR
+
+PR #129 に内容を統合したため、merge 時に以下を close する。
+
+Closes #123
+Closes #124
+```
+
+すでに統合 PR を merge 済みで closing reference が自動発火しない場合は、統合先 PR の本文やコメントに記録を残し、置き換え元 PR へ superseded 理由をコメントして close する。
+
 ## Process Update Rule
 
 Process updates come first. If the user changes the development workflow, review sequence, storage policy, or agent rules, update the canonical operating files before applying that new workflow to the current task.


### PR DESCRIPTION
## 概要

置き換え PR を作る場合の運用ルールを `AGENTS.md` に追加しました。

- 統合先 PR の本文に `## 置き換える PR` 節を置く
- 置き換え元 PR / Issue を `Closes #...` で明記する
- すでに merge 済みで closing reference が自動発火しない場合は、統合先 PR に記録し、置き換え元 PR へ superseded コメントを残して close する

## 検証

- `git diff --check`

## 外部状態の変更

今回の指示に基づき、先行して以下を実施済みです。

- PR #128 の本文に `Closes #123` / `Closes #124` を追記
- PR #123 を superseded コメント付きで close
- PR #124 を superseded コメント付きで close

## Review gate

- intent review: ユーザーの「置き換え PR で対応 PR を自動 close できるようにする」意図に照らして実施、通過
- fresh pre PR review: AGENTS.md 差分、外部状態変更、`git diff --check` 結果を確認して実施、通過